### PR TITLE
Add --needed pacman flag

### DIFF
--- a/res/arch/prereqs.sh
+++ b/res/arch/prereqs.sh
@@ -1,4 +1,4 @@
-pacman -Sy binutils \
+pacman -Sy --needed binutils \
         efitools \
         util-linux \
         sbsigntools \


### PR DESCRIPTION
The `--needed` flag prevents reinstallation of up-to-date packages.  This ensures users will not unnecessarily redownload and reinstall packages if they already have one or more of the packages installed.